### PR TITLE
Run ConfigMap generation per environment

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,12 +25,9 @@ git checkout ${INPUT_BRANCH_NAME}
 git pull origin ${INPUT_BRANCH_NAME} --rebase
 
 indent() { sed '2,$s/^/  /'; }
-env() { sed 's/configs\///g'; }
 
-for d in configs/*
+for ENV in ci qa stage prod
 do
-  ENV=$(echo "$d" | env)
-
   mkdir -p $CONFIGMAPS_TARGET/${ENV}
 
   PERMISSION_DIR=${WORKSPACE}/configs/${ENV}/permissions


### PR DESCRIPTION
This will rely on a change to the `rbac-config` repo where we have the config
namespaced like so (in an upcoming PR):
```
/configs/ci/permissions/*.json
/configs/ci/roles/*.json

/configs/qa/permissions/*.json
/configs/qa/roles/*.json

/configs/stage/permissions/*.json
/configs/stage/roles/*.json

/configs/prod/permissions/*.json
/configs/prod/roles/*.json
```

The entrypoint script will now iterate over each `/configs/<env>/` dir, and
create configmaps for each environment, placing two files in `_private/configmaps/<env>/`
for roles and permissions.

I've tested locally by:
- modifying the `Dockerfile` to copy over a local `configs` directory, namespaced
as it will be in `rbac-config`
- bypassed all of the git logic, and modified the entrypoint to output each generated template
- ran each template through `oc process -f <file>`