### PR TITLE
Don't checkout the `configmaps` branch until after the changes are applied

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,10 +20,6 @@ git config http.sslVerify false
 git config user.name "[GitHub] - Automated Action"
 git config user.email "actions@github.com"
 
-git fetch
-git checkout ${INPUT_BRANCH_NAME}
-git pull origin ${INPUT_BRANCH_NAME} --rebase
-
 indent() { sed '2,$s/^/  /'; }
 
 for ENV in ci qa stage prod
@@ -56,6 +52,10 @@ objects:
     qontract.recycle: "true"' >> $f
   done
 done
+
+git fetch
+git checkout ${INPUT_BRANCH_NAME}
+git pull origin ${INPUT_BRANCH_NAME} --rebase
 
 # push the changes
 git add .


### PR DESCRIPTION
Currently, we'll checkout the `configmaps` branch prior to the generation being
run, which means no changes will be applied. We need to run the generation, then
checkout the `configmaps` branch to ensure we're adding the changes.