### PR TITLE
Fix annotations indentation

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,9 +48,11 @@ objects:
   # add annotations
   for f in $PERMISSION_CONFIGMAP_FILE $ROLE_CONFIGMAP_FILE
   do
-    echo '  annotations:
-    qontract.recycle: "true"' >> $f
+    echo '    annotations:
+      qontract.recycle: "true"' >> $f
   done
+
+  cat "${CONFIGMAPS_TARGET}/ci/rbac-config.yml"
 done
 
 git fetch


### PR DESCRIPTION
Before this fix, `oc process` would still work, however the `annotation` needed
were not indented correctly, so were not picked up by `app-interface`.