### PR TITLE
RHCLOUD-35560 - Action to validate generated schema before merge

### DIFF
--- a/convert-config/entrypoint.sh
+++ b/convert-config/entrypoint.sh
@@ -78,7 +78,7 @@ cd ..
 # Run KSL compiler
 for ENV in stage prod
 do # ex. configs/stage/schemas
-  ./ksl-schema-language/bin/ksl -o configs/${ENV}/schemas/schema.zed configs/${ENV}/schemas/src/*.ksl configs/${ENV}/schemas/src/*.json
+  ./ksl-schema-language/bin/ksl -o configs/${ENV}/schemas/schema.zed configs/${ENV}/schemas/src/*.ksl configs/${ENV}/schemas/src/*.json || exit 1
   rm configs/${ENV}/schemas/src/rbac_v1_permissions.json
 done
 

--- a/validate-schema/Dockerfile
+++ b/validate-schema/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10 AS builder
 
 ARG TARGETARCH
 USER root
-RUN microdnf install -y tar gzip make which
+RUN microdnf install -y tar gzip make which git
 
 # install platform specific go version
 RUN curl -O -J  https://dl.google.com/go/go1.22.7.linux-${TARGETARCH}.tar.gz && \

--- a/validate-schema/Dockerfile
+++ b/validate-schema/Dockerfile
@@ -1,0 +1,14 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10 AS builder
+
+ARG TARGETARCH
+USER root
+RUN microdnf install -y tar gzip make which
+
+# install platform specific go version
+RUN curl -O -J  https://dl.google.com/go/go1.22.7.linux-${TARGETARCH}.tar.gz && \
+    tar -C /usr/local -xzf go1.22.7.linux-${TARGETARCH}.tar.gz && \
+    ln -s /usr/local/go/bin/go /usr/local/bin/go
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/validate-schema/README.md
+++ b/validate-schema/README.md
@@ -1,0 +1,21 @@
+# Generate Schema Validation Action
+This will validate generated schema from the underlying ksl files.
+
+Usage:
+```
+on:
+  pull_request:
+    branches:
+      - main
+name: Validate generated schema
+jobs:
+  validate_schema:
+    name: validate schema
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate & validate schema
+        uses: RedHatInsights/rbac-config-actions/validate-schema@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+```

--- a/validate-schema/action.yml
+++ b/validate-schema/action.yml
@@ -1,0 +1,11 @@
+name: RBAC Pre-commit Action
+description: Ensures that underlying ksl files generate a valid schema
+runs:
+  using: docker
+  image: Dockerfile
+  args:
+    - ${{ inputs.token }}
+inputs:
+  token:
+    description: GitHub token
+    required: true

--- a/validate-schema/entrypoint.sh
+++ b/validate-schema/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh -l
+
+# generate schemas
+# Clone ksl-schema-language repo
+git clone --depth=1 https://github.com/project-kessel/ksl-schema-language.git
+
+# Build KSL compiler binary
+cd ksl-schema-language
+mkdir -p bin/
+go build -gcflags "all=-N -l" -o ./bin/ ./...
+cd ..
+
+# Run KSL compiler
+for ENV in stage prod
+do # ex. configs/stage/schemas
+  ./ksl-schema-language/bin/ksl -o configs/${ENV}/schemas/schema.zed configs/${ENV}/schemas/src/*.ksl configs/${ENV}/schemas/src/*.json
+  rm configs/${ENV}/schemas/src/rbac_v1_permissions.json
+done
+
+# Remove KSL repo
+rm -rf ksl-schema-language/

--- a/validate-schema/entrypoint.sh
+++ b/validate-schema/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -l
 
+set -e
+
 # generate schemas
 # Clone ksl-schema-language repo
 git clone --depth=1 https://github.com/project-kessel/ksl-schema-language.git

--- a/validate-schema/entrypoint.sh
+++ b/validate-schema/entrypoint.sh
@@ -1,7 +1,5 @@
 #!/bin/sh -l
 
-set -e
-
 # generate schemas
 # Clone ksl-schema-language repo
 git clone --depth=1 https://github.com/project-kessel/ksl-schema-language.git
@@ -15,7 +13,7 @@ cd ..
 # Run KSL compiler
 for ENV in stage prod
 do # ex. configs/stage/schemas
-  ./ksl-schema-language/bin/ksl -o configs/${ENV}/schemas/schema.zed configs/${ENV}/schemas/src/*.ksl configs/${ENV}/schemas/src/*.json
+  ./ksl-schema-language/bin/ksl -o configs/${ENV}/schemas/schema.zed configs/${ENV}/schemas/src/*.ksl configs/${ENV}/schemas/src/*.json || exit 1
   rm configs/${ENV}/schemas/src/rbac_v1_permissions.json
 done
 


### PR DESCRIPTION
Creates a separate action that uses the same building blocks of `convert-config` to validate that the underlying ksl genrates valid schema. 

Cannot just call `convert-config` due to the possibility of a new PR closing an open change. Everytime `convert-config` runs it will delete the old branch and update it with the new changes which make it unsuitable for a test case that runs during PR checks.

Related: [RHCLOUD-35560](https://issues.redhat.com/browse/RHCLOUD-35560)