### PR TITLE
Expand KSIL generator to apply host-centric permission patterns

### DIFF
--- a/generate-v1-only-permissions/main.go
+++ b/generate-v1-only-permissions/main.go
@@ -31,16 +31,17 @@ func main() {
 		panic(err)
 	}
 
+	hostsonlyApps, err := v2.GetHostOnlyApps(*kslSrc)
+	if err != nil {
+		panic(err)
+	}
+
 	perms, err := v1.ExtractRBACPermissions(*rbacPermissions, migratedApps)
 	if err != nil {
 		panic(err)
 	}
 
-	for i, perm := range perms {
-		perms[i] = v1PermToV2Perm(perm)
-	}
-
-	v2.WriteV1OnlyPermissionsFile(*kslSrc, perms)
+	v2.WriteV1OnlyPermissionsFile(*kslSrc, hostsonlyApps, perms)
 }
 
 func v1PermToV2Perm(v1Perm string) string {

--- a/generate-v1-only-permissions/v2/V2.go
+++ b/generate-v1-only-permissions/v2/V2.go
@@ -2,9 +2,12 @@ package v2
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
+	v1 "github.com/RedHatInsights/rbac-config-actions/generatepermissions/v1"
 	"github.com/project-kessel/ksl-schema-language/pkg/intermediate"
 )
 
@@ -15,9 +18,67 @@ const (
 )
 
 func GetMigratedApps(kslPath string) (map[string]bool, error) {
+	return readAppList(filepath.Join(kslPath, "migrated_apps.lst"))
+}
+
+func GetHostOnlyApps(kslPath string) (map[string]bool, error) {
+	return readAppList(filepath.Join(kslPath, "hostsonly_apps.lst"))
+}
+
+func WriteV1OnlyPermissionsFile(kslPath string, hostsonly_apps map[string]bool, perms []v1.Permission) error {
+	refs := []*intermediate.ExtensionReference{}
+
+	for _, perm := range perms {
+		v2_perm := to_v2_perm(perm)
+
+		if hostsonly_apps[perm.App] {
+			if !perm.IsWildcard() {
+				/*
+					refs = append(refs, &intermediate.ExtensionReference{Namespace: "rbac", Name: "add_v1_based_permission", Params: map[string]string{"app": escape_v1_string(perm.App), "resource": escape_v1_string(perm.ResourceType), "verb": escape_v1_string(perm.Verb), "v2_perm": v2_perm}})
+					refs = append(refs, &intermediate.ExtensionReference{Namespace: "hbi", Name: "expose_host_permission", Params: map[string]string{"v2_perm": v2_perm, "host_perm": to_host_perm(perm)}})
+				*/
+
+				v2_assigned_perm := v2_perm + "_assigned"
+				refs = append(refs, &intermediate.ExtensionReference{Namespace: "rbac", Name: "add_v1_based_permission", Params: map[string]string{"app": escape_v1_string(perm.App), "resource": escape_v1_string(perm.ResourceType), "verb": escape_v1_string(perm.Verb), "v2_perm": v2_assigned_perm}})
+				refs = append(refs, &intermediate.ExtensionReference{Namespace: "rbac", Name: "add_contingent_permission", Params: map[string]string{"first": "inventory_host_view", "second": v2_assigned_perm, "contingent": v2_perm}})
+				refs = append(refs, &intermediate.ExtensionReference{Namespace: "hbi", Name: "expose_host_permission", Params: map[string]string{"v2_perm": v2_perm, "host_perm": to_host_perm(perm)}})
+			}
+		} else {
+			refs = append(refs, &intermediate.ExtensionReference{Namespace: "rbac", Name: "add_v1only_permission", Params: map[string]string{"perm": v2_perm}})
+		}
+	}
+
+	ns := &intermediate.Namespace{Name: "rbac_v1_permissions", Imports: []string{"rbac", "hbi"}, ExtensionReferences: refs}
+
+	f, err := os.OpenFile(filepath.Join(kslPath, "src", V1OnlyPermissionsFile), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	return intermediate.Store(ns, f)
+}
+
+func to_v2_perm(perm v1.Permission) string {
+	return fmt.Sprintf("%s_%s_%s", escape_v1_string(perm.App), escape_v1_string(perm.Verb), escape_v1_string(perm.ResourceType))
+}
+
+func to_host_perm(perm v1.Permission) string {
+	return fmt.Sprintf("%s_%s", escape_v1_string(perm.Verb), escape_v1_string(perm.ResourceType))
+}
+
+func escape_v1_string(val string) string {
+	val = strings.ReplaceAll(val, "-", "_")
+	val = strings.ReplaceAll(val, ".", "_")
+	val = strings.ReplaceAll(val, "*", "all")
+
+	return val
+}
+
+func readAppList(filePath string) (map[string]bool, error) {
 	apps := map[string]bool{}
 
-	listFile, err := os.Open(filepath.Join(kslPath, "migrated_apps.lst"))
+	listFile, err := os.Open(filePath)
 	if err != nil {
 		return apps, err
 	}
@@ -29,22 +90,4 @@ func GetMigratedApps(kslPath string) (map[string]bool, error) {
 	}
 
 	return apps, scanner.Err()
-}
-
-func WriteV1OnlyPermissionsFile(kslPath string, perms []string) error {
-	refs := []*intermediate.ExtensionReference{}
-
-	for _, perm := range perms {
-		refs = append(refs, &intermediate.ExtensionReference{Namespace: "rbac", Name: "add_v1only_permission", Params: map[string]string{"perm": perm}})
-	}
-
-	ns := &intermediate.Namespace{Name: "rbac_v1_permissions", Imports: []string{"rbac"}, ExtensionReferences: refs}
-
-	f, err := os.OpenFile(filepath.Join(kslPath, "src", V1OnlyPermissionsFile), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	return intermediate.Store(ns, f)
 }


### PR DESCRIPTION
Should apply to listed apps only (none for now)

Depends on https://github.com/RedHatInsights/rbac-config/pull/593