### PR TITLE
Go install compatibility

### DIFF
--- a/convert-config/entrypoint.sh
+++ b/convert-config/entrypoint.sh
@@ -87,6 +87,7 @@ rm -rf ksl-schema-language/
 
 # push the changes
 git add .
+git add --force configs/${ENV}/schemas/schema.zed #Override .gitignore
 timestamp=$(date -u)
 git commit -m "[GitHub] - Automated ConfigMap & Schema Generation: ${timestamp} - ${GITHUB_SHA}" || exit 0
 git push origin ${INPUT_BRANCH_NAME}

--- a/convert-config/entrypoint.sh
+++ b/convert-config/entrypoint.sh
@@ -72,7 +72,7 @@ git clone --depth=1 https://github.com/project-kessel/ksl-schema-language.git
 # Build KSL compiler binary
 cd ksl-schema-language
 mkdir -p bin/
-go build -gcflags "all=-N -l" -o ./bin/ ./...
+go build -gcflags "all=-N -l" -o ./bin/ ./cmd/ksl/...
 cd ..
 
 # Run KSL compiler

--- a/generate-v1-only-permissions/Dockerfile
+++ b/generate-v1-only-permissions/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /workspace
 COPY . ./
 
 RUN go mod vendor
-RUN go build -o bin/generate-v1-only-permissions main.go
+RUN go build -o bin/generate-v1-only-permissions cmd/generate-v1-only-permissions/main.go
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10
 

--- a/generate-v1-only-permissions/README.md
+++ b/generate-v1-only-permissions/README.md
@@ -1,8 +1,48 @@
-# Generate V1-Only Permissions Data Action
-This will generate a KSIL file representing permissions declared in V1 but not yet migrated to the V2 model.
+# Generate V1-Only Permissions Data
 
-Usage:
+This utility generates a KSIL file representing permissions declared in V1 but not yet migrated to the V2 model.
+
+## Installation
+
+### As a Go Tool
+
+You can install this utility directly using `go install`:
+
+```bash
+# Install from the repository
+go install github.com/RedHatInsights/rbac-config-actions/generate-v1-only-permissions/cmd/generate-v1-only-permissions@latest
+
+# Or install locally after cloning the repository
+cd generate-v1-only-permissions
+go install ./cmd/generate-v1-only-permissions
 ```
+
+### Usage as Command Line Tool
+
+After installation, you can use the tool directly:
+
+```bash
+generate-v1-only-permissions -ksl /path/to/ksl/project -rbac-permissions-json /path/to/rbac/permissions
+```
+
+#### Command Line Options
+
+- `-ksl`: The path to the ksl project directory (where the migrated_apps.lst file is) - **required**
+- `-rbac-permissions-json`: The path to the directory containing RBAC permissions .json files for the current environment - **required**
+
+#### Example
+
+```bash
+generate-v1-only-permissions \
+  -ksl /home/user/ksl-project \
+  -rbac-permissions-json /home/user/rbac-permissions
+```
+
+## Usage as GitHub Action
+
+You can also use this tool as a GitHub Action in your workflows:
+
+```yaml
 on:
   pull_request:
     branches:

--- a/generate-v1-only-permissions/cmd/generate-v1-only-permissions/main.go
+++ b/generate-v1-only-permissions/cmd/generate-v1-only-permissions/main.go
@@ -4,8 +4,8 @@ import (
 	"flag"
 	"strings"
 
-	v1 "github.com/RedHatInsights/rbac-config-actions/generatepermissions/v1"
-	v2 "github.com/RedHatInsights/rbac-config-actions/generatepermissions/v2"
+	v1 "github.com/RedHatInsights/rbac-config-actions/generate-v1-only-permissions/v1"
+	v2 "github.com/RedHatInsights/rbac-config-actions/generate-v1-only-permissions/v2"
 )
 
 func main() {

--- a/generate-v1-only-permissions/go.mod
+++ b/generate-v1-only-permissions/go.mod
@@ -1,4 +1,4 @@
-module github.com/RedHatInsights/rbac-config-actions/generatepermissions
+module github.com/RedHatInsights/rbac-config-actions/generate-v1-only-permissions
 
 go 1.22.2
 


### PR DESCRIPTION
Makes the generate-v1-only-permissions utility compatible with go install

Note: this PR has external dependencies! Check:
- https://github.com/project-kessel/ksl-schema-language/pull/34